### PR TITLE
fix: Disabled double proxy for same-origin image URLs

### DIFF
--- a/src/client/utils/url.ts
+++ b/src/client/utils/url.ts
@@ -1,7 +1,28 @@
 import { state } from "../state";
 
+const getCurrentOrigin = (): string => {
+  const candidate = globalThis.location?.origin;
+  return typeof candidate === "string" ? candidate : "";
+};
+
 export const proxyImageUrl = (url: string): string => {
   if (!url) return "";
+
+  if (url.startsWith("/") && !url.startsWith("//")) {
+    return url;
+  }
+
+  const origin = getCurrentOrigin();
+  if (origin) {
+    try {
+      if (new URL(url, origin).origin === origin) {
+        return url;
+      }
+    } catch {
+      //
+    }
+  }
+
   return `/api/proxy/image?url=${encodeURIComponent(url)}`;
 };
 

--- a/tests/public/url.test.ts
+++ b/tests/public/url.test.ts
@@ -2,15 +2,48 @@ import { describe, test, expect } from "bun:test";
 import { buildSearchUrl, proxyImageUrl, faviconUrl } from "../../src/client/utils/url";
 import { state } from "../../src/client/state";
 
+function withMockLocation(href: string, callback: () => void) {
+  const previous = Object.getOwnPropertyDescriptor(globalThis, "location");
+
+  Object.defineProperty(globalThis, "location", {
+    value: new URL(href),
+    configurable: true,
+  });
+
+  try {
+    callback();
+  } finally {
+    if (previous) {
+      Object.defineProperty(globalThis, "location", previous);
+    } else {
+      delete (globalThis as { location?: URL }).location;
+    }
+  }
+}
+
 describe("public/url", () => {
   test("proxyImageUrl returns empty for empty url", () => {
     expect(proxyImageUrl("")).toBe("");
   });
 
-  test("proxyImageUrl returns path with encoded url", () => {
+  test("proxyImageUrl proxies cross-origin absolute urls", () => {
     const out = proxyImageUrl("https://example.com/img.png");
     expect(out).toContain("/api/proxy/image");
     expect(out).toContain("url=");
+  });
+
+  test("proxyImageUrl keeps root-relative same-origin urls direct", () => {
+    expect(proxyImageUrl("/api/plugin/example/image?id=1")).toBe(
+      "/api/plugin/example/image?id=1",
+    );
+  });
+
+  test("proxyImageUrl keeps same-origin absolute urls direct", () => {
+    withMockLocation("https://degoog.local/search?q=test", () => {
+      expect(
+        proxyImageUrl("https://degoog.local/api/plugin/example/image?id=1"),
+      ).toBe("https://degoog.local/api/plugin/example/image?id=1");
+    });
   });
 
   test("faviconUrl returns empty for invalid url", () => {


### PR DESCRIPTION
Added detecting if image URL is same-origin to avoid wrapping URL that points to plugin route in `/api/proxy/image?url=`.

### Background
I've developed plugins that search in my private instances of various apps (like Immich). To allow for authentication when downloading thumbnails, their URLs are already proxied: they use plugin routes, but Degoog wraps them in `/api/proxy/image` anyway and the resulting image source looks like this:
```
/api/proxy/image?url=https%3A%2F%2Fdegoog.url%2Fapi%2Fplugin%2Fimmich%2Fthumbnail%3Fid%3Dabcdef-12345
```

While not ideal, that would still work, except if, like me, you have Degoog instance deployed behind reverse proxy with auth. Then the backend cannot reach itself via public URL because it lacks the browser's session.