### PR TITLE
Feature/requests from 25

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -60,6 +60,44 @@
           you add in Settings → Store).
         </p>
 
+        <h2>Default enabled/disabled engines</h2>
+        <p>
+          Search engines have two separate layers of “enabled” state:
+          <strong>instance defaults</strong> and <strong>your browser’s saved
+          selection</strong>.
+        </p>
+        <ul>
+          <li>
+            <strong>Instance defaults (server-side)</strong>: on startup, Degoog
+            computes a default enabled/disabled value for every engine. Engines
+            that are marked as <em>disabled by default</em>, or engines that
+            have required settings that are not configured, start out disabled.
+            You can override these defaults by saving a
+            <code>data/default-engines.json</code> file (this is what the
+            Settings → Engines “Save defaults” button writes).
+          </li>
+          <li>
+            <strong>Your selection (client-side)</strong>: the Engines tab
+            stores your toggles in your browser (IndexedDB). Those saved values
+            take priority over the instance defaults for that browser/profile,
+            so your choice persists even if the server defaults change later.
+          </li>
+        </ul>
+        <p>
+          Example <code>data/default-engines.json</code>:
+        </p>
+        <pre><code>{
+  "google": true,
+  "duckduckgo": true,
+  "bing": false,
+  "engine-my-custom-engine": true
+}</code></pre>
+        <p>
+          When you toggle engines on the Engines tab, the enabled/disabled
+          state is sent along with each search request, so different users (or
+          different browsers) can use different engine sets at the same time.
+        </p>
+
         <h2>Where things live</h2>
         <table>
           <thead>

--- a/src/client/settings/engines-tab.ts
+++ b/src/client/settings/engines-tab.ts
@@ -7,10 +7,10 @@ import type { ExtensionMeta, EngineRecord, AllExtensions } from "../types";
 const t = window.scopedT("core");
 const themeT = window.scopedT("themes/degoog");
 
-const _TAB_TYPES = new Set(["web", "images", "videos", "news"]);
+const TAB_TYPES = new Set(["web", "images", "videos", "news"]);
 
 const _typeLabel = (type: string): string =>
-  _TAB_TYPES.has(type)
+  TAB_TYPES.has(type)
     ? themeT(`search-templates.tabs.${type}`)
     : type.charAt(0).toUpperCase() + type.slice(1);
 

--- a/src/client/settings/engines-tab.ts
+++ b/src/client/settings/engines-tab.ts
@@ -92,6 +92,9 @@ export async function initEnginesTab(
     }
     html += `</div></div>`;
   }
+  if (allowConfigure) {
+    html += `<div class="settings-page-actions"><button class="btn btn--secondary" id="save-default-engines" type="button">${t("settings-page.extensions.save-defaults")}</button></div>`;
+  }
   container.innerHTML = html;
 
   container
@@ -114,5 +117,26 @@ export async function initEnginesTab(
           if (ext) openModal(ext);
         });
       });
+
+    document.getElementById("save-default-engines")?.addEventListener("click", async () => {
+      const btn = document.getElementById("save-default-engines");
+      try {
+        const token = sessionStorage.getItem("degoog-settings-token");
+        const headers: Record<string, string> = { "Content-Type": "application/json" };
+        if (token) headers["x-settings-token"] = token;
+        await fetch("/api/settings/default-engines", {
+          method: "POST",
+          headers,
+          body: JSON.stringify(enabledMap),
+        });
+        if (btn) {
+          const prev = btn.textContent;
+          btn.textContent = t("settings-page.server.saved");
+          setTimeout(() => { btn.textContent = prev; }, 1200);
+        }
+      } catch {
+        if (btn) btn.textContent = t("settings-page.server.save-failed-network");
+      }
+    });
   }
 }

--- a/src/client/settings/engines-tab.ts
+++ b/src/client/settings/engines-tab.ts
@@ -34,9 +34,7 @@ const _renderEngineCard = (
 ): string => {
   const isEnabled = enabledMap[engine.id] !== false;
   const status =
-    allowConfigure && engine.configurable
-      ? getConfigStatus(engine)
-      : null;
+    allowConfigure && engine.configurable ? getConfigStatus(engine) : null;
   const badge =
     status === "configured"
       ? '<span class="ext-configured-badge"></span>'
@@ -118,25 +116,32 @@ export async function initEnginesTab(
         });
       });
 
-    document.getElementById("save-default-engines")?.addEventListener("click", async () => {
-      const btn = document.getElementById("save-default-engines");
-      try {
-        const token = sessionStorage.getItem("degoog-settings-token");
-        const headers: Record<string, string> = { "Content-Type": "application/json" };
-        if (token) headers["x-settings-token"] = token;
-        await fetch("/api/settings/default-engines", {
-          method: "POST",
-          headers,
-          body: JSON.stringify(enabledMap),
-        });
-        if (btn) {
-          const prev = btn.textContent;
-          btn.textContent = t("settings-page.server.saved");
-          setTimeout(() => { btn.textContent = prev; }, 1200);
+    document
+      .getElementById("save-default-engines")
+      ?.addEventListener("click", async () => {
+        const btn = document.getElementById("save-default-engines");
+        try {
+          const token = sessionStorage.getItem("degoog-settings-token");
+          const headers: Record<string, string> = {
+            "Content-Type": "application/json",
+          };
+          if (token) headers["x-settings-token"] = token;
+          await fetch("/api/settings/default-engines", {
+            method: "POST",
+            headers,
+            body: JSON.stringify(enabledMap),
+          });
+          if (btn) {
+            const prev = btn.textContent;
+            btn.textContent = t("settings-page.server.saved");
+            setTimeout(() => {
+              btn.textContent = prev;
+            }, 1200);
+          }
+        } catch {
+          if (btn)
+            btn.textContent = t("settings-page.server.save-failed-network");
         }
-      } catch {
-        if (btn) btn.textContent = t("settings-page.server.save-failed-network");
-      }
-    });
+      });
   }
 }

--- a/src/client/settings/general-tab.ts
+++ b/src/client/settings/general-tab.ts
@@ -22,6 +22,19 @@ export async function initAppearanceSettings(): Promise<void> {
         localStorage.setItem(THEME_KEY, value);
       } catch {}
       applyTheme(value);
+      try {
+        const token = sessionStorage.getItem("degoog-settings-token");
+        if (token) {
+          await fetch("/api/settings/general", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "x-settings-token": token,
+            },
+            body: JSON.stringify({ defaultTheme: value }),
+          });
+        }
+      } catch {}
     });
   }
 

--- a/src/client/settings/general-tab.ts
+++ b/src/client/settings/general-tab.ts
@@ -8,6 +8,8 @@ import {
 import { applyTheme } from "../utils/theme";
 import { requestInstallPrompt } from "../utils/install-prompt";
 
+const t = window.scopedT("core");
+
 export async function initAppearanceSettings(): Promise<void> {
   const themeSelect = document.getElementById(
     "theme-select",
@@ -22,21 +24,40 @@ export async function initAppearanceSettings(): Promise<void> {
         localStorage.setItem(THEME_KEY, value);
       } catch {}
       applyTheme(value);
-      try {
-        const token = sessionStorage.getItem("degoog-settings-token");
-        if (token) {
-          await fetch("/api/settings/general", {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              "x-settings-token": token,
-            },
-            body: JSON.stringify({ defaultTheme: value }),
-          });
-        }
-      } catch {}
     });
   }
+
+  document
+    .getElementById("save-default-theme")
+    ?.addEventListener("click", async () => {
+      const btn = document.getElementById("save-default-theme");
+      const select = document.getElementById(
+        "theme-select",
+      ) as HTMLSelectElement | null;
+      const value = select?.value ?? "system";
+      try {
+        const token = sessionStorage.getItem("degoog-settings-token");
+        if (!token) throw new Error("missing token");
+        await fetch("/api/settings/general", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "x-settings-token": token,
+          },
+          body: JSON.stringify({ defaultTheme: value }),
+        });
+        if (btn) {
+          const prev = btn.textContent;
+          btn.textContent = t("settings-page.server.saved");
+          setTimeout(() => {
+            btn.textContent = prev;
+          }, 1200);
+        }
+      } catch {
+        if (btn)
+          btn.textContent = t("settings-page.server.save-failed-network");
+      }
+    });
 
   const openInNewTab = document.getElementById(
     "settings-open-new-tab",

--- a/src/client/settings/plugins-tab.ts
+++ b/src/client/settings/plugins-tab.ts
@@ -55,13 +55,9 @@ export function initPluginsTab(allExtensions: AllExtensions): void {
   const container = document.getElementById("plugins-content");
   if (!container) return;
 
-  const custom = allExtensions.plugins.filter(
-    (p) => p.source === "plugin",
-  );
+  const custom = allExtensions.plugins.filter((p) => p.source === "plugin");
 
-  const builtin = allExtensions.plugins.filter(
-    (p) => p.source !== "plugin",
-  );
+  const builtin = allExtensions.plugins.filter((p) => p.source !== "plugin");
 
   let html = "";
   if (custom.length > 0) {

--- a/src/client/settings/server-tab.ts
+++ b/src/client/settings/server-tab.ts
@@ -54,6 +54,13 @@ export async function initServerTab(
     "settings-streaming-max-retries",
   ) as HTMLInputElement | null;
 
+  const domainBlockEnabled = document.getElementById("settings-domain-block-enabled") as HTMLInputElement | null;
+  const domainBlockWrap = document.getElementById("settings-domain-block-wrap");
+  const domainBlockList = document.getElementById("settings-domain-block-list") as HTMLTextAreaElement | null;
+  const domainReplaceEnabled = document.getElementById("settings-domain-replace-enabled") as HTMLInputElement | null;
+  const domainReplaceWrap = document.getElementById("settings-domain-replace-wrap");
+  const domainReplaceList = document.getElementById("settings-domain-replace-list") as HTMLTextAreaElement | null;
+
   try {
     const res = await fetch("/api/settings/general", {
       headers: authHeaders(getToken),
@@ -72,6 +79,10 @@ export async function initServerTab(
         streamingEnabled?: string;
         streamingAutoRetry?: string;
         streamingMaxRetries?: string;
+        domainBlockEnabled?: string;
+        domainBlockList?: string;
+        domainReplaceEnabled?: string;
+        domainReplaceList?: string;
       };
       if (languagesEnabled && languagesWrap) {
         languagesEnabled.checked = data.languagesEnabled === "true";
@@ -115,6 +126,16 @@ export async function initServerTab(
       }
       if (streamingMaxRetries)
         streamingMaxRetries.value = data.streamingMaxRetries ?? "";
+      if (domainBlockEnabled && domainBlockWrap) {
+        domainBlockEnabled.checked = data.domainBlockEnabled === "true";
+        domainBlockWrap.style.display = domainBlockEnabled.checked ? "block" : "none";
+      }
+      if (domainBlockList) domainBlockList.value = data.domainBlockList ?? "";
+      if (domainReplaceEnabled && domainReplaceWrap) {
+        domainReplaceEnabled.checked = data.domainReplaceEnabled === "true";
+        domainReplaceWrap.style.display = domainReplaceEnabled.checked ? "block" : "none";
+      }
+      if (domainReplaceList) domainReplaceList.value = data.domainReplaceList ?? "";
     }
   } catch {}
 
@@ -148,6 +169,16 @@ export async function initServerTab(
       streamingRetryWrap.style.display = streamingAutoRetry.checked
         ? "block"
         : "none";
+    });
+  }
+  if (domainBlockEnabled && domainBlockWrap) {
+    domainBlockEnabled.addEventListener("change", () => {
+      domainBlockWrap.style.display = domainBlockEnabled.checked ? "block" : "none";
+    });
+  }
+  if (domainReplaceEnabled && domainReplaceWrap) {
+    domainReplaceEnabled.addEventListener("change", () => {
+      domainReplaceWrap.style.display = domainReplaceEnabled.checked ? "block" : "none";
     });
   }
   const _rateLimitPayload = (): Record<string, string> => {
@@ -189,6 +220,10 @@ export async function initServerTab(
             streamingEnabled: streamingEnabled?.checked ? "true" : "false",
             streamingAutoRetry: streamingAutoRetry?.checked ? "true" : "false",
             streamingMaxRetries: streamingMaxRetries?.value.trim() ?? "",
+            domainBlockEnabled: domainBlockEnabled?.checked ? "true" : "false",
+            domainBlockList: domainBlockList?.value.trim() ?? "",
+            domainReplaceEnabled: domainReplaceEnabled?.checked ? "true" : "false",
+            domainReplaceList: domainReplaceList?.value.trim() ?? "",
           }),
         });
       } catch {}

--- a/src/client/settings/server-tab.ts
+++ b/src/client/settings/server-tab.ts
@@ -1,257 +1,185 @@
+import { getInputElement } from "../utils/dom";
 import { authHeaders, jsonHeaders } from "../utils/request";
 import { initProxyTest } from "./proxy-test";
 
 const t = window.scopedT("core");
 
+type ServerSettingsData = {
+  proxyEnabled?: string;
+  proxyUrls?: string;
+  rateLimitEnabled?: string;
+  rateLimitBurstWindow?: string;
+  rateLimitBurstMax?: string;
+  rateLimitLongWindow?: string;
+  rateLimitLongMax?: string;
+  languagesEnabled?: string;
+  languages?: string;
+  streamingEnabled?: string;
+  streamingAutoRetry?: string;
+  streamingMaxRetries?: string;
+  domainBlockEnabled?: string;
+  domainBlockList?: string;
+  domainReplaceEnabled?: string;
+  domainReplaceList?: string;
+};
+
+const el = (id: string) => getInputElement(`settings-${id}`);
+const val = (id: string) => el(id)?.value.trim() ?? "";
+const boolStr = (id: string) => (el(id)?.checked ? "true" : "false");
+
+function _bindToggle(checkboxId: string, wrapId: string) {
+  const checkbox = el(checkboxId);
+  const wrap = el(wrapId);
+  if (checkbox && wrap) {
+    const update = () => {
+      wrap.style.display = checkbox.checked ? "block" : "none";
+    };
+    checkbox.addEventListener("change", update);
+    update();
+  }
+}
+
+function _setToggle(id: string, state?: string) {
+  const checkbox = el(id);
+  if (checkbox && state !== undefined) {
+    checkbox.checked = state === "true";
+    checkbox.dispatchEvent(new Event("change"));
+  }
+}
+
+function _setVal(id: string, value?: string) {
+  const element = el(id);
+  if (element && value !== undefined) element.value = value;
+}
+
 export async function initServerTab(
   getToken: () => string | null,
 ): Promise<void> {
-  const proxyEnabled = document.getElementById(
-    "settings-proxy-enabled",
-  ) as HTMLInputElement | null;
-  const proxyUrlsWrap = document.getElementById("settings-proxy-urls-wrap");
-  const proxyUrls = document.getElementById(
-    "settings-proxy-urls",
-  ) as HTMLTextAreaElement | null;
-  const rateLimitEnabled = document.getElementById(
-    "settings-rate-limit-enabled",
-  ) as HTMLInputElement | null;
-  const rateLimitOptions = document.getElementById(
-    "settings-rate-limit-options",
-  );
-  const rateLimitBurstWindow = document.getElementById(
-    "settings-rate-limit-burst-window",
-  ) as HTMLInputElement | null;
-  const rateLimitBurstMax = document.getElementById(
-    "settings-rate-limit-burst-max",
-  ) as HTMLInputElement | null;
-  const rateLimitLongWindow = document.getElementById(
-    "settings-rate-limit-long-window",
-  ) as HTMLInputElement | null;
-  const rateLimitLongMax = document.getElementById(
-    "settings-rate-limit-long-max",
-  ) as HTMLInputElement | null;
+  _bindToggle("proxy-enabled", "proxy-urls-wrap");
+  _bindToggle("languages-enabled", "languages-wrap");
+  _bindToggle("rate-limit-enabled", "rate-limit-options");
+  _bindToggle("streaming-enabled", "streaming-options");
+  _bindToggle("streaming-auto-retry", "streaming-retry-wrap");
+  _bindToggle("domain-block-enabled", "domain-block-wrap");
+  _bindToggle("domain-replace-enabled", "domain-replace-wrap");
 
-  const languagesEnabled = document.getElementById(
-    "settings-languages-enabled",
-  ) as HTMLInputElement | null;
-  const languagesWrap = document.getElementById("settings-languages-wrap");
-  const languagesTextarea = document.getElementById(
-    "settings-languages",
-  ) as HTMLTextAreaElement | null;
-
-  const streamingEnabled = document.getElementById(
-    "settings-streaming-enabled",
-  ) as HTMLInputElement | null;
-  const streamingOptions = document.getElementById("settings-streaming-options");
-  const streamingAutoRetry = document.getElementById(
-    "settings-streaming-auto-retry",
-  ) as HTMLInputElement | null;
-  const streamingRetryWrap = document.getElementById(
-    "settings-streaming-retry-wrap",
-  );
-  const streamingMaxRetries = document.getElementById(
-    "settings-streaming-max-retries",
-  ) as HTMLInputElement | null;
-
-  const domainBlockEnabled = document.getElementById("settings-domain-block-enabled") as HTMLInputElement | null;
-  const domainBlockWrap = document.getElementById("settings-domain-block-wrap");
-  const domainBlockList = document.getElementById("settings-domain-block-list") as HTMLTextAreaElement | null;
-  const domainReplaceEnabled = document.getElementById("settings-domain-replace-enabled") as HTMLInputElement | null;
-  const domainReplaceWrap = document.getElementById("settings-domain-replace-wrap");
-  const domainReplaceList = document.getElementById("settings-domain-replace-list") as HTMLTextAreaElement | null;
+  if (el("proxy-enabled")) initProxyTest(getToken);
 
   try {
     const res = await fetch("/api/settings/general", {
       headers: authHeaders(getToken),
     });
     if (res.ok) {
-      const data = (await res.json()) as {
-        proxyEnabled?: string;
-        proxyUrls?: string;
-        rateLimitEnabled?: string;
-        rateLimitBurstWindow?: string;
-        rateLimitBurstMax?: string;
-        rateLimitLongWindow?: string;
-        rateLimitLongMax?: string;
-        languagesEnabled?: string;
-        languages?: string;
-        streamingEnabled?: string;
-        streamingAutoRetry?: string;
-        streamingMaxRetries?: string;
-        domainBlockEnabled?: string;
-        domainBlockList?: string;
-        domainReplaceEnabled?: string;
-        domainReplaceList?: string;
-      };
-      if (languagesEnabled && languagesWrap) {
-        languagesEnabled.checked = data.languagesEnabled === "true";
-        languagesWrap.style.display = languagesEnabled.checked
-          ? "block"
-          : "none";
-      }
-      if (languagesTextarea) languagesTextarea.value = data.languages ?? "";
-      if (proxyEnabled) {
-        proxyEnabled.checked = data.proxyEnabled === "true";
-      }
-      if (proxyUrls) proxyUrls.value = data.proxyUrls ?? "";
-      if (proxyUrlsWrap) {
-        proxyUrlsWrap.style.display = proxyEnabled?.checked ? "block" : "none";
-      }
-      if (rateLimitEnabled && rateLimitOptions) {
-        rateLimitEnabled.checked = data.rateLimitEnabled === "true";
-        rateLimitOptions.style.display = rateLimitEnabled.checked
-          ? "block"
-          : "none";
-      }
-      if (rateLimitBurstWindow)
-        rateLimitBurstWindow.value = data.rateLimitBurstWindow ?? "";
-      if (rateLimitBurstMax)
-        rateLimitBurstMax.value = data.rateLimitBurstMax ?? "";
-      if (rateLimitLongWindow)
-        rateLimitLongWindow.value = data.rateLimitLongWindow ?? "";
-      if (rateLimitLongMax)
-        rateLimitLongMax.value = data.rateLimitLongMax ?? "";
-      if (streamingEnabled && streamingOptions) {
-        streamingEnabled.checked = data.streamingEnabled === "true";
-        streamingOptions.style.display = streamingEnabled.checked
-          ? "block"
-          : "none";
-      }
-      if (streamingAutoRetry && streamingRetryWrap) {
-        streamingAutoRetry.checked = data.streamingAutoRetry === "true";
-        streamingRetryWrap.style.display = streamingAutoRetry.checked
-          ? "block"
-          : "none";
-      }
-      if (streamingMaxRetries)
-        streamingMaxRetries.value = data.streamingMaxRetries ?? "";
-      if (domainBlockEnabled && domainBlockWrap) {
-        domainBlockEnabled.checked = data.domainBlockEnabled === "true";
-        domainBlockWrap.style.display = domainBlockEnabled.checked ? "block" : "none";
-      }
-      if (domainBlockList) domainBlockList.value = data.domainBlockList ?? "";
-      if (domainReplaceEnabled && domainReplaceWrap) {
-        domainReplaceEnabled.checked = data.domainReplaceEnabled === "true";
-        domainReplaceWrap.style.display = domainReplaceEnabled.checked ? "block" : "none";
-      }
-      if (domainReplaceList) domainReplaceList.value = data.domainReplaceList ?? "";
+      const data = (await res.json()) as ServerSettingsData;
+
+      _setToggle("proxy-enabled", data.proxyEnabled);
+      _setVal("proxy-urls", data.proxyUrls);
+
+      _setToggle("languages-enabled", data.languagesEnabled);
+      _setVal("languages", data.languages);
+
+      _setToggle("rate-limit-enabled", data.rateLimitEnabled);
+      _setVal("rate-limit-burst-window", data.rateLimitBurstWindow);
+      _setVal("rate-limit-burst-max", data.rateLimitBurstMax);
+      _setVal("rate-limit-long-window", data.rateLimitLongWindow);
+      _setVal("rate-limit-long-max", data.rateLimitLongMax);
+
+      _setToggle("streaming-enabled", data.streamingEnabled);
+      _setToggle("streaming-auto-retry", data.streamingAutoRetry);
+      _setVal("streaming-max-retries", data.streamingMaxRetries);
+
+      _setToggle("domain-block-enabled", data.domainBlockEnabled);
+      _setVal("domain-block-list", data.domainBlockList);
+
+      _setToggle("domain-replace-enabled", data.domainReplaceEnabled);
+      _setVal("domain-replace-list", data.domainReplaceList);
     }
   } catch {}
 
-  if (proxyEnabled && proxyUrlsWrap) {
-    proxyEnabled.addEventListener("change", () => {
-      proxyUrlsWrap.style.display = proxyEnabled.checked ? "block" : "none";
-    });
-    initProxyTest(getToken);
-  }
-  if (languagesEnabled && languagesWrap) {
-    languagesEnabled.addEventListener("change", () => {
-      languagesWrap.style.display = languagesEnabled.checked ? "block" : "none";
-    });
-  }
-  if (rateLimitEnabled && rateLimitOptions) {
-    rateLimitEnabled.addEventListener("change", () => {
-      rateLimitOptions.style.display = rateLimitEnabled.checked
-        ? "block"
-        : "none";
-    });
-  }
-  if (streamingEnabled && streamingOptions) {
-    streamingEnabled.addEventListener("change", () => {
-      streamingOptions.style.display = streamingEnabled.checked
-        ? "block"
-        : "none";
-    });
-  }
-  if (streamingAutoRetry && streamingRetryWrap) {
-    streamingAutoRetry.addEventListener("change", () => {
-      streamingRetryWrap.style.display = streamingAutoRetry.checked
-        ? "block"
-        : "none";
-    });
-  }
-  if (domainBlockEnabled && domainBlockWrap) {
-    domainBlockEnabled.addEventListener("change", () => {
-      domainBlockWrap.style.display = domainBlockEnabled.checked ? "block" : "none";
-    });
-  }
-  if (domainReplaceEnabled && domainReplaceWrap) {
-    domainReplaceEnabled.addEventListener("change", () => {
-      domainReplaceWrap.style.display = domainReplaceEnabled.checked ? "block" : "none";
-    });
-  }
-  const _rateLimitPayload = (): Record<string, string> => {
+  const getRateLimitPayload = () => {
+    const enabled = el("rate-limit-enabled")?.checked;
     const payload: Record<string, string> = {
-      rateLimitEnabled: rateLimitEnabled?.checked ? "true" : "false",
+      rateLimitEnabled: enabled ? "true" : "false",
     };
-    if (
-      rateLimitEnabled?.checked &&
-      rateLimitBurstWindow &&
-      rateLimitBurstMax &&
-      rateLimitLongWindow &&
-      rateLimitLongMax
-    ) {
-      const bw = rateLimitBurstWindow.value.trim();
-      const bm = rateLimitBurstMax.value.trim();
-      const lw = rateLimitLongWindow.value.trim();
-      const lm = rateLimitLongMax.value.trim();
-      if (bw) payload.rateLimitBurstWindow = bw;
-      if (bm) payload.rateLimitBurstMax = bm;
-      if (lw) payload.rateLimitLongWindow = lw;
-      if (lm) payload.rateLimitLongMax = lm;
+
+    if (enabled) {
+      const bw = val("rate-limit-burst-window");
+      const bm = val("rate-limit-burst-max");
+      const lw = val("rate-limit-long-window");
+      const lm = val("rate-limit-long-max");
+
+      if (bw && bm && lw && lm) {
+        Object.assign(payload, {
+          rateLimitBurstWindow: bw,
+          rateLimitBurstMax: bm,
+          rateLimitLongWindow: lw,
+          rateLimitLongMax: lm,
+        });
+      }
     }
+
     return payload;
   };
 
-  document
-    .getElementById("settings-save")
-    ?.addEventListener("click", async () => {
-      try {
-        await fetch("/api/settings/general", {
-          method: "POST",
-          headers: jsonHeaders(getToken),
-          body: JSON.stringify({
-            proxyEnabled: proxyEnabled?.checked ? "true" : "false",
-            proxyUrls: proxyUrls?.value.trim() ?? "",
-            languagesEnabled: languagesEnabled?.checked ? "true" : "false",
-            languages: languagesTextarea?.value.trim() ?? "",
-            ..._rateLimitPayload(),
-            streamingEnabled: streamingEnabled?.checked ? "true" : "false",
-            streamingAutoRetry: streamingAutoRetry?.checked ? "true" : "false",
-            streamingMaxRetries: streamingMaxRetries?.value.trim() ?? "",
-            domainBlockEnabled: domainBlockEnabled?.checked ? "true" : "false",
-            domainBlockList: domainBlockList?.value.trim() ?? "",
-            domainReplaceEnabled: domainReplaceEnabled?.checked ? "true" : "false",
-            domainReplaceList: domainReplaceList?.value.trim() ?? "",
-          }),
-        });
-      } catch {}
-      const btn = document.getElementById("settings-save");
-      if (btn) {
-        const prev = btn.textContent;
-        btn.textContent = t("settings-page.server.saved");
-        setTimeout(() => {
-          btn.textContent = prev;
-        }, 1200);
-      }
-    });
+  const handleButtonState = (
+    id: string,
+    action: () => Promise<void>,
+    successKey: string,
+    failKey?: string,
+  ) => {
+    const btn = document.getElementById(id);
+    if (!btn) return;
 
-  document
-    .getElementById("settings-cache-clear")
-    ?.addEventListener("click", async () => {
-      const btn = document.getElementById("settings-cache-clear");
+    btn.addEventListener("click", async () => {
+      const prev = btn.textContent;
       try {
-        await fetch("/api/cache/clear", { method: "POST" });
-        if (btn) {
-          const prev = btn.textContent;
-          btn.textContent = t("settings-page.server.cache-cleared");
-          setTimeout(() => {
-            btn.textContent = prev;
-          }, 1500);
-        }
+        await action();
+        btn.textContent = t(successKey);
       } catch {
-        if (btn) btn.textContent = t("settings-page.server.cache-failed");
+        if (failKey) btn.textContent = t(failKey);
+      } finally {
+        setTimeout(
+          () => {
+            btn.textContent = prev;
+          },
+          failKey ? 1500 : 1200,
+        );
       }
     });
+  };
+
+  handleButtonState(
+    "settings-save",
+    async () => {
+      await fetch("/api/settings/general", {
+        method: "POST",
+        headers: jsonHeaders(getToken),
+        body: JSON.stringify({
+          proxyEnabled: boolStr("proxy-enabled"),
+          proxyUrls: val("proxy-urls"),
+          languagesEnabled: boolStr("languages-enabled"),
+          languages: val("languages"),
+          ...getRateLimitPayload(),
+          streamingEnabled: boolStr("streaming-enabled"),
+          streamingAutoRetry: boolStr("streaming-auto-retry"),
+          streamingMaxRetries: val("streaming-max-retries"),
+          domainBlockEnabled: boolStr("domain-block-enabled"),
+          domainBlockList: val("domain-block-list"),
+          domainReplaceEnabled: boolStr("domain-replace-enabled"),
+          domainReplaceList: val("domain-replace-list"),
+        }),
+      });
+    },
+    "settings-page.server.saved",
+  );
+
+  handleButtonState(
+    "settings-cache-clear",
+    async () => {
+      const res = await fetch("/api/cache/clear", { method: "POST" });
+      if (!res.ok) throw new Error();
+    },
+    "settings-page.server.cache-cleared",
+    "settings-page.server.cache-failed",
+  );
 }

--- a/src/client/settings/transports-tab.ts
+++ b/src/client/settings/transports-tab.ts
@@ -53,18 +53,22 @@ export function initTransportsTab(allExtensions: AllExtensions): void {
     "transport-curl",
     "transport-curl-fallback",
   ]);
-  const custom = transports.filter((t) => !BUILTIN_IDS.has(t.id));
-  const builtin = transports.filter((t) => BUILTIN_IDS.has(t.id));
+  const custom = transports.filter(
+    (transport) => !BUILTIN_IDS.has(transport.id),
+  );
+  const builtin = transports.filter((transport) =>
+    BUILTIN_IDS.has(transport.id),
+  );
 
   let html = "";
   if (custom.length > 0) {
     html += `<div class="ext-group"><h3 class="ext-group-label">${escapeHtml(t("settings-page.extensions.group-transports"))}</h3><div class="ext-cards">`;
-    for (const t of custom) html += _renderTransportCard(t);
+    for (const transport of custom) html += _renderTransportCard(transport);
     html += "</div></div>";
   }
   if (builtin.length > 0) {
     html += `<div class="ext-group"><h3 class="ext-group-label">${escapeHtml(t("settings-page.extensions.group-builtin-transports"))}</h3><div class="ext-cards">`;
-    for (const t of builtin) html += _renderTransportCard(t);
+    for (const transport of builtin) html += _renderTransportCard(transport);
     html += "</div></div>";
   }
   container.innerHTML = html;
@@ -93,7 +97,7 @@ export function initTransportsTab(allExtensions: AllExtensions): void {
     .forEach((btn) => {
       btn.addEventListener("click", () => {
         const id = btn.dataset.id;
-        const ext = transports.find((t) => t.id === id);
+        const ext = transports.find((transport) => transport.id === id);
         if (ext) openModal(ext);
       });
     });

--- a/src/client/utils/dom.ts
+++ b/src/client/utils/dom.ts
@@ -41,3 +41,7 @@ export const getConfigStatus = (ext: {
   );
   return missingRequired ? "needs-config" : "configured";
 };
+
+export const getInputElement = (id: string) => {
+  return document.getElementById(id) as HTMLInputElement | null;
+};

--- a/src/client/utils/theme.ts
+++ b/src/client/utils/theme.ts
@@ -30,5 +30,13 @@ export async function initTheme(): Promise<void> {
       localStorage.setItem(THEME_KEY, saved);
     } catch {}
     applyTheme(saved);
+    return;
   }
+  try {
+    const res = await fetch("/api/settings/appearance");
+    const data = (await res.json()) as { theme?: string };
+    if (data.theme && data.theme !== "system") {
+      applyTheme(data.theme);
+    }
+  } catch {}
 }

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -74,6 +74,17 @@
       "rate-limit-burst-max": "Burst max requests",
       "rate-limit-long-window": "Long window (seconds)",
       "rate-limit-long-max": "Long max requests",
+      "domain-block-heading": "Domain blocking",
+      "domain-block-desc": "Hide search results from specific domains. One domain per line. Subdomains are included automatically. Wrap a line in /slashes/ for regex.",
+      "domain-block-enable": "Enable domain blocking",
+      "domain-block-enable-aria": "Enable domain blocking",
+      "domain-block-list-label": "Blocked domains (one per line)",
+      "domain-block-regex-help": "Regex entries must be wrapped in /slashes/ and use JavaScript RegExp syntax (no flags). They are matched against the URL hostname only (not the full URL). Example: /(^|\\\\.)instagram\\\\.com$/ blocks instagram.com and all subdomains; /^www\\\\.instagram\\\\.com$/ blocks only www.instagram.com.",
+      "domain-replace-heading": "Domain replacement",
+      "domain-replace-desc": "Replace domains in search result URLs. Use the format: source.com -> target.com (one per line). Subdomains are matched automatically, and the path is preserved.",
+      "domain-replace-enable": "Enable domain replacement",
+      "domain-replace-enable-aria": "Enable domain replacement",
+      "domain-replace-list-label": "Replacement rules (one per line)",
       "saved": "Saved",
       "save-failed-network": "Save failed. Please try again."
     },
@@ -123,7 +134,8 @@
       "group-transports": "Transports",
       "group-builtin-transports": "Built-in transports",
       "group-themes": "Themes",
-      "apply-failed": "Failed"
+      "apply-failed": "Failed",
+      "save-defaults": "Save as instance defaults"
     },
     "errors": {
       "load-extensions": "Failed to load extensions.",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -19,7 +19,8 @@
     },
     "appearance": {
       "heading": "Appearance",
-      "desc": "Choose your preferred theme."
+      "desc": "Choose your preferred theme.",
+      "save-defaults": "Save as instance default"
     },
     "theme": {
       "system": "System default",

--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -19,7 +19,8 @@
     },
     "appearance": {
       "heading": "Apparence",
-      "desc": "Choisissez le thème souhaité."
+      "desc": "Choisissez le thème souhaité.",
+      "save-defaults": "Enregistrer comme valeur par défaut de l'instance"
     },
     "theme": {
       "system": "Par défaut du système",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -19,7 +19,8 @@
     },
     "appearance": {
       "heading": "Aspetto",
-      "desc": "Scegli il tema preferito."
+      "desc": "Scegli il tema preferito.",
+      "save-defaults": "Salva come predefinito dell’istanza"
     },
     "theme": {
       "system": "Predefinito di sistema",

--- a/src/public/settings.html
+++ b/src/public/settings.html
@@ -314,6 +314,85 @@
               </div>
             </section>
 
+            <section class="settings-section" id="settings-section-domain-block">
+              <h2 class="settings-section-heading">
+                {{t:settings-page.server.domain-block-heading}}
+              </h2>
+              <p class="settings-desc">
+                {{t:settings-page.server.domain-block-desc}}
+              </p>
+              <label class="settings-toggle-wrap">
+                <input
+                  type="checkbox"
+                  id="settings-domain-block-enabled"
+                  class="settings-toggle"
+                  aria-label="{{t:settings-page.server.domain-block-enable-aria}}"
+                />
+                <span class="toggle-slider"></span>
+                <span class="settings-toggle-label"
+                  >{{t:settings-page.server.domain-block-enable}}</span
+                >
+              </label>
+              <div
+                class="settings-proxy-urls-wrap"
+                id="settings-domain-block-wrap"
+                style="display: none"
+              >
+                <label
+                  for="settings-domain-block-list"
+                  class="settings-proxy-urls-label"
+                  >{{t:settings-page.server.domain-block-list-label}}</label
+                >
+                <p class="settings-desc">
+                  {{t:settings-page.server.domain-block-regex-help}}
+                </p>
+                <textarea
+                  id="settings-domain-block-list"
+                  class="settings-proxy-urls"
+                  rows="5"
+                  placeholder="quora.com&#10;tiktok.com&#10;/.*\.spam\.net/"
+                ></textarea>
+              </div>
+            </section>
+
+            <section class="settings-section" id="settings-section-domain-replace">
+              <h2 class="settings-section-heading">
+                {{t:settings-page.server.domain-replace-heading}}
+              </h2>
+              <p class="settings-desc">
+                {{t:settings-page.server.domain-replace-desc}}
+              </p>
+              <label class="settings-toggle-wrap">
+                <input
+                  type="checkbox"
+                  id="settings-domain-replace-enabled"
+                  class="settings-toggle"
+                  aria-label="{{t:settings-page.server.domain-replace-enable-aria}}"
+                />
+                <span class="toggle-slider"></span>
+                <span class="settings-toggle-label"
+                  >{{t:settings-page.server.domain-replace-enable}}</span
+                >
+              </label>
+              <div
+                class="settings-proxy-urls-wrap"
+                id="settings-domain-replace-wrap"
+                style="display: none"
+              >
+                <label
+                  for="settings-domain-replace-list"
+                  class="settings-proxy-urls-label"
+                  >{{t:settings-page.server.domain-replace-list-label}}</label
+                >
+                <textarea
+                  id="settings-domain-replace-list"
+                  class="settings-proxy-urls"
+                  rows="5"
+                  placeholder="reddit.com -> teddit.example.com&#10;twitter.com -> nitter.example.com"
+                ></textarea>
+              </div>
+            </section>
+
             <section class="settings-section" id="settings-section-proxy">
               <h2 class="settings-section-heading">
                 {{t:settings-page.server.proxy-heading}}

--- a/src/public/settings.html
+++ b/src/public/settings.html
@@ -126,6 +126,15 @@
                   <option value="dark">{{t:settings-page.theme.dark}}</option>
                 </select>
               </div>
+              <div class="settings-page-actions">
+                <button
+                  class="btn btn--secondary"
+                  id="save-default-theme"
+                  type="button"
+                >
+                  {{t:settings-page.appearance.save-defaults}}
+                </button>
+              </div>
             </section>
 
             <section class="settings-section">
@@ -314,7 +323,10 @@
               </div>
             </section>
 
-            <section class="settings-section" id="settings-section-domain-block">
+            <section
+              class="settings-section"
+              id="settings-section-domain-block"
+            >
               <h2 class="settings-section-heading">
                 {{t:settings-page.server.domain-block-heading}}
               </h2>
@@ -355,7 +367,10 @@
               </div>
             </section>
 
-            <section class="settings-section" id="settings-section-domain-replace">
+            <section
+              class="settings-section"
+              id="settings-section-domain-replace"
+            >
               <h2 class="settings-section-heading">
                 {{t:settings-page.server.domain-replace-heading}}
               </h2>

--- a/src/server/extensions/engines/registry.ts
+++ b/src/server/extensions/engines/registry.ts
@@ -15,7 +15,8 @@ import {
 } from "../../utils/plugin-settings";
 import { createTranslatorFromPath } from "../../utils/translation";
 import { getTransportNames } from "../transports/registry";
-import { enginesDir } from "../../utils/paths";
+import { enginesDir, defaultEnginesFile } from "../../utils/paths";
+import { readFileSync } from "fs";
 import { createRegistry } from "../registry-factory";
 import { BingEngine } from "./bing";
 import { BingImagesEngine } from "./bing-images";
@@ -338,11 +339,22 @@ export const getActiveWebEngines = async (
   return active;
 };
 
+const _loadDefaultEngineOverrides = (): Record<string, boolean> => {
+  try {
+    const raw = readFileSync(defaultEnginesFile(), "utf-8");
+    return JSON.parse(raw) as Record<string, boolean>;
+  } catch {
+    return {};
+  }
+};
+
 export function getDefaultEngineConfig(): Record<string, boolean> {
   const entries = getEngineRegistry();
   const engineMap = getEngineMap();
+  const overrides = _loadDefaultEngineOverrides();
   return Object.fromEntries(
     entries.map((e) => {
+      if (e.id in overrides) return [e.id, overrides[e.id]];
       const instance = engineMap[e.id];
       const disabledByDefault =
         instance &&

--- a/src/server/routes/search.ts
+++ b/src/server/routes/search.ts
@@ -31,6 +31,10 @@ import {
   type SlotPluginContext,
   type TimeFilter,
 } from "../types";
+import {
+  filterBlockedDomains,
+  applyDomainReplacements,
+} from "../utils/domain-filter";
 import * as cache from "../utils/cache";
 import { getLocale } from "../utils/hono";
 import { logger } from "../utils/logger";
@@ -438,10 +442,13 @@ router.get("/api/search/stream", async (c) => {
             if (timing.resultCount > 0) {
               allRawResults.push({ results, multiplier: score });
               allTimings.push(timing);
+              const rawScored = scoreResults(allRawResults);
+              const afterBlock = await filterBlockedDomains(rawScored);
+              const finalResults = await applyDomainReplacements(afterBlock);
               _send("engine-result", {
                 engine: engineName,
                 timing,
-                results: scoreResults(allRawResults),
+                results: finalResults,
                 retry: isRetry,
                 attempt,
               });
@@ -460,10 +467,13 @@ router.get("/api/search/stream", async (c) => {
           }
 
           allTimings.push(lastTiming);
+          const rawScored = scoreResults(allRawResults);
+          const afterBlock = await filterBlockedDomains(rawScored);
+          const finalResults = await applyDomainReplacements(afterBlock);
           _send("engine-result", {
             engine: engineName,
             timing: lastTiming,
-            results: scoreResults(allRawResults),
+            results: finalResults,
             retry: false,
             attempt: 0,
           });
@@ -472,7 +482,9 @@ router.get("/api/search/stream", async (c) => {
 
       void Promise.all(enginePromises).then(async () => {
         const totalTime = Math.round(performance.now() - start);
-        const finalResults = scoreResults(allRawResults);
+        const rawFinal = scoreResults(allRawResults);
+        const afterBlock = await filterBlockedDomains(rawFinal);
+        const finalResults = await applyDomainReplacements(afterBlock);
         let relatedSearches: string[] = [];
         if (searchType === "web" && page === 1) {
           relatedSearches = await fetchRelatedSearches(query).catch(
@@ -847,8 +859,10 @@ router.get("/api/tab-search", async (c) => {
     }
 
     const totalTime = Math.round(performance.now() - startTime);
+    const afterBlock = await filterBlockedDomains(allResults);
+    const finalResults = await applyDomainReplacements(afterBlock);
     return c.json({
-      results: allResults,
+      results: finalResults,
       totalPages,
       page,
       engineTimings,

--- a/src/server/routes/settings-auth.ts
+++ b/src/server/routes/settings-auth.ts
@@ -1,9 +1,11 @@
 import { Hono, type Context } from "hono";
+import { readFile, writeFile } from "fs/promises";
 import { getSettings, setSettings, asString } from "../utils/plugin-settings";
 import { getMiddleware } from "../extensions/middleware/registry";
 import { isPublicInstance } from "../utils/public-instance";
 import { outgoingFetch } from "../utils/outgoing";
 import { getRandomUserAgent } from "../utils/user-agents";
+import { defaultEnginesFile } from "../utils/paths";
 
 const DEGOOG_SETTINGS_ID = "degoog-settings";
 
@@ -198,6 +200,11 @@ router.post("/api/settings/general", async (c) => {
     "streamingEnabled",
     "streamingAutoRetry",
     "streamingMaxRetries",
+    "defaultTheme",
+    "domainBlockEnabled",
+    "domainBlockList",
+    "domainReplaceEnabled",
+    "domainReplaceList",
   ];
   const updates: Record<string, string> = {};
   for (const key of allowed) {
@@ -259,6 +266,41 @@ router.get("/api/settings/proxy-test", async (c) => {
     proxyIp,
     match: directIp !== null && proxyIp !== null && directIp === proxyIp,
   });
+});
+
+router.get("/api/settings/appearance", async (c) => {
+  const settings = await getSettings(DEGOOG_SETTINGS_ID);
+  return c.json({
+    theme: asString(settings.defaultTheme) || "system",
+  });
+});
+
+router.get("/api/settings/default-engines", async (c) => {
+  const token = getSettingsTokenFromRequest(c);
+  if (!(await validateSettingsToken(token))) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+  try {
+    const raw = await readFile(defaultEnginesFile(), "utf-8");
+    return c.json(JSON.parse(raw));
+  } catch {
+    return c.json({});
+  }
+});
+
+router.post("/api/settings/default-engines", async (c) => {
+  const token = getSettingsTokenFromRequest(c);
+  if (!(await validateSettingsToken(token))) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+  let body: Record<string, boolean>;
+  try {
+    body = await c.req.json<Record<string, boolean>>();
+  } catch {
+    return c.json({ error: "Invalid JSON" }, 400);
+  }
+  await writeFile(defaultEnginesFile(), JSON.stringify(body, null, 2), "utf-8");
+  return c.json({ ok: true });
 });
 
 export default router;

--- a/src/server/search.ts
+++ b/src/server/search.ts
@@ -17,6 +17,10 @@ import type {
   SearchType,
   TimeFilter,
 } from "./types";
+import {
+  filterBlockedDomains,
+  applyDomainReplacements,
+} from "./utils/domain-filter";
 import { outgoingFetch, parseOutgoingTransport } from "./utils/outgoing";
 import { asString, getSettings } from "./utils/plugin-settings";
 
@@ -299,6 +303,8 @@ export const search = async (
   }
 
   const scored = scoreResults(allResults);
+  const filtered = await filterBlockedDomains(scored);
+  const processed = await applyDomainReplacements(filtered);
 
   let relatedSearches: string[] = [];
 
@@ -312,7 +318,7 @@ export const search = async (
   const totalTime = Math.round(performance.now() - start);
 
   return {
-    results: scored,
+    results: processed,
     query,
     totalTime,
     type,

--- a/src/server/utils/domain-filter.ts
+++ b/src/server/utils/domain-filter.ts
@@ -1,0 +1,74 @@
+import type { ScoredResult } from "../types";
+import { getSettings, asString } from "./plugin-settings";
+
+const DEGOOG_SETTINGS_ID = "degoog-settings";
+
+const _matchesDomain = (hostname: string, pattern: string): boolean => {
+  if (pattern.startsWith("/") && pattern.endsWith("/")) {
+    const regex = new RegExp(pattern.slice(1, -1));
+    return regex.test(hostname);
+  }
+  return hostname === pattern || hostname.endsWith(`.${pattern}`);
+};
+
+const _parseBlockList = (raw: string): string[] =>
+  raw
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+const _parseReplaceList = (
+  raw: string,
+): { source: string; target: string }[] =>
+  raw
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.includes("->"))
+    .map((line) => {
+      const [source, target] = line.split("->").map((s) => s.trim());
+      return { source, target };
+    });
+
+export const filterBlockedDomains = async (
+  results: ScoredResult[],
+): Promise<ScoredResult[]> => {
+  const settings = await getSettings(DEGOOG_SETTINGS_ID);
+  if (asString(settings.domainBlockEnabled) !== "true") return results;
+
+  const patterns = _parseBlockList(asString(settings.domainBlockList));
+  if (patterns.length === 0) return results;
+
+  return results.filter((result) => {
+    try {
+      const hostname = new URL(result.url).hostname;
+      return !patterns.some((pattern) => _matchesDomain(hostname, pattern));
+    } catch {
+      return true;
+    }
+  });
+};
+
+export const applyDomainReplacements = async (
+  results: ScoredResult[],
+): Promise<ScoredResult[]> => {
+  const settings = await getSettings(DEGOOG_SETTINGS_ID);
+  if (asString(settings.domainReplaceEnabled) !== "true") return results;
+
+  const rules = _parseReplaceList(asString(settings.domainReplaceList));
+  if (rules.length === 0) return results;
+
+  return results.map((result) => {
+    try {
+      const url = new URL(result.url);
+      for (const rule of rules) {
+        if (_matchesDomain(url.hostname, rule.source)) {
+          url.hostname = rule.target;
+          return { ...result, url: url.toString() };
+        }
+      }
+      return result;
+    } catch {
+      return result;
+    }
+  });
+};

--- a/src/server/utils/paths.ts
+++ b/src/server/utils/paths.ts
@@ -20,3 +20,6 @@ export const aliasesFile = (): string =>
 
 export const pluginSettingsFile = (): string =>
   process.env.DEGOOG_PLUGIN_SETTINGS_FILE ?? join(_dataDir(), "plugin-settings.json");
+
+export const defaultEnginesFile = (): string =>
+  process.env.DEGOOG_DEFAULT_ENGINES_FILE ?? join(_dataDir(), "default-engines.json");


### PR DESCRIPTION
# Enable domain replacement in results. eg: repalce reddit[.]com -> troddit[.]domain[.]com.

- Navigate to settings -> server 
- Enable domain replacement
- Type with format `oldbasedomain.com -> newbasedomain.com`

# Allow blocking of search results by domain (best with regex support). eg: blocking quora[.]com , tiktok[.]com

- Navigate to settings 0> server
- Enable blocking of search results
- You can use both hardcoded urls or regexes (read the description). Regexes must be typed between `//`

# Support global, instance-wide settings so preferences persist across multiple devices.

- Added a button to persist engine enable/disable settings 
- Added a button to persist light/dark theme