### PR TITLE
Feature/stream show skeleton before results

### DIFF
--- a/src/client/utils/search-utils.ts
+++ b/src/client/utils/search-utils.ts
@@ -1,4 +1,3 @@
-import { skeletonGlance } from "../animations/skeleton";
 import { appendSlotPanels } from "../modules/renderer/render-slots";
 import { SlotPanelPosition, type ScoredResult, type SlotPanel } from "../types";
 import { escapeHtml } from "./dom";
@@ -15,9 +14,9 @@ export async function fetchGlancePanels(
   const signal = glanceAbortController.signal;
   const glanceEl = document.getElementById("at-a-glance");
   if (!results || results.length === 0) {
+    if (glanceEl) glanceEl.innerHTML = "";
     return;
   }
-  if (glanceEl) glanceEl.innerHTML = skeletonGlance();
   try {
     const res = await fetch("/api/slots/glance", {
       method: "POST",

--- a/src/client/utils/streaming-search.ts
+++ b/src/client/utils/streaming-search.ts
@@ -99,8 +99,6 @@ export async function performStreamingSearch(
   }
   const resultsMeta = document.getElementById("results-meta");
   if (resultsMeta) resultsMeta.textContent = "Searching...";
-  const glanceEl = document.getElementById("at-a-glance");
-  if (glanceEl) glanceEl.innerHTML = type === "web" ? skeletonGlance() : "";
   const resultsList = document.getElementById("results-list");
   if (resultsList) {
     if (type === "images") {
@@ -116,6 +114,8 @@ export async function performStreamingSearch(
   const sidebar = document.getElementById("results-sidebar");
   if (sidebar) sidebar.innerHTML = "";
   clearSlotPanels();
+  const glanceEl = document.getElementById("at-a-glance");
+  if (glanceEl) glanceEl.innerHTML = type === "web" ? skeletonGlance() : "";
   document.title = `${query} - degoog`;
 
   const urlParams = new URLSearchParams({ q: query });

--- a/src/styles/components/_glance.scss
+++ b/src/styles/components/_glance.scss
@@ -1,3 +1,7 @@
+#at-a-glance:not(:empty) {
+  margin-bottom: $space-4;
+}
+
 .glance-box {
   background: var(--bg-light);
   border-radius: $radius-lg;


### PR DESCRIPTION
When streaming result was enabled the at-a-glance box was waiting for results before even showing the skeleton.
This was causing the page to shift once it was finally loaded in.

Moved things around so it now shows the skeleton while results load in and eventually shows the content of it (if it needs to wait for results, like in the case of ai-summary).