### PR TITLE
Github/Issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,51 @@
+name: Bug Report
+description: Report a bug in Degoog
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: input
+    id: version
+    attributes:
+      label: What version of Degoog are you using?
+      placeholder: e.g. 1.2.3
+    validations:
+      required: false
+  - type: input
+    id: platform
+    attributes:
+      label: What platform is it deployed on?
+      placeholder: e.g. Docker on Ubuntu 22.04, Node.js on Debian 12
+    validations:
+      required: false
+  - type: textarea
+    id: steps
+    attributes:
+      label: What steps can reproduce the bug?
+      placeholder: |
+        1. Go to '...'
+        2. Search for '...'
+        3. Click on '...'
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What is the expected behavior?
+      placeholder: Describe what you expected to happen.
+    validations:
+      required: false
+  - type: textarea
+    id: actual
+    attributes:
+      label: What do you see instead?
+      placeholder: Describe what actually happened.
+    validations:
+      required: false
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional information
+      placeholder: Any other context, screenshots, or logs that might help.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Ask a Question
     url: https://discord.gg/invite/mMuk2WzVZu

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a Question
+    url: https://discord.gg/invite/mMuk2WzVZu
+    about: Please ask and answer questions on our Discord server.

--- a/.github/ISSUE_TEMPLATE/crash_report.yml
+++ b/.github/ISSUE_TEMPLATE/crash_report.yml
@@ -1,0 +1,28 @@
+name: Crash Report
+description: Report a crash in Degoog
+title: "[Crash]: "
+labels: ["bug", "crash"]
+body:
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: How can we reproduce the crash?
+      placeholder: Steps to reproduce the crash, if known.
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output.
+      render: shell
+    validations:
+      required: false
+  - type: textarea
+    id: stacktrace
+    attributes:
+      label: Stack Trace
+      description: Please paste the full stack trace.
+      render: shell
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/documentation_issue.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_issue.yml
@@ -1,0 +1,31 @@
+name: Documentation Issue
+description: Report an issue with the documentation
+title: "[Docs]: "
+labels: ["documentation"]
+body:
+  - type: dropdown
+    id: type
+    attributes:
+      label: What is the type of issue?
+      options:
+        - Missing documentation
+        - Incorrect
+        - Confusing
+        - Example code not working
+        - Something else
+    validations:
+      required: true
+  - type: textarea
+    id: issue
+    attributes:
+      label: What is the issue?
+      placeholder: Describe the documentation issue in detail.
+    validations:
+      required: true
+  - type: input
+    id: location
+    attributes:
+      label: Where did you find it?
+      placeholder: e.g. URL, page name, or section
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature Request
+description: Suggest a new feature for Degoog
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > **Note:** Before submitting, please consider whether your feature could be implemented as a [plugin](https://fccview.github.io/degoog/plugins.html).
+        > If it can, we encourage you to create your own plugin repository and use it via the [store](https://fccview.github.io/degoog/store.html) instead of opening a feature request here.
+        > Feature requests here should be for changes to Degoog's core functionality.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is the problem this feature would solve?
+      placeholder: A clear description of the problem or pain point.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What is the feature you are proposing to solve the problem?
+      placeholder: Describe the solution you'd like.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: What alternatives have you considered?
+      placeholder: Describe any alternative solutions or features you've considered.
+    validations:
+      required: false


### PR DESCRIPTION
# Github/Issues templates

Provides templates for github issues to prevent people to write all kind of things

## Clanker

This pull request adds a comprehensive set of GitHub issue templates to standardize and streamline how users report bugs, crashes, documentation issues, and feature requests for the project. It also updates the issue configuration to guide users toward appropriate support channels.

**New Issue Templates:**

* Added a bug report template (`bug_report.yml`) to collect details on software bugs, including version, platform, steps to reproduce, and expected/actual behavior.
* Added a crash report template (`crash_report.yml`) to capture reproduction steps, log output, and stack traces for application crashes.
* Added a documentation issue template (`documentation_issue.yml`) to report missing, incorrect, or confusing documentation, with options to specify issue type and location.
* Added a feature request template (`feature_request.yml`) that encourages plugin-based solutions and collects problem descriptions, proposals, and alternatives.

**Issue Configuration Updates:**

* Updated the issue configuration (`config.yml`) to disable blank issues and provide a Discord link for questions, directing users to the appropriate support channel.