### PR TITLE
Fix/translation error handler

### DIFF
--- a/src/server/utils/logger.ts
+++ b/src/server/utils/logger.ts
@@ -22,8 +22,7 @@ export const logger = LEVELS.reduce(
     acc[level] = (namespace: string, ...args: unknown[]) => {
       if (LEVELS.indexOf(LOG_LEVEL) < LEVELS.indexOf(level)) return;
       CONSOLE_LEVELS[level](
-        `${CONSOLE_COLORS[level]}${level.toUpperCase()} [${namespace}]`,
-        "\x1b[0m",
+        `${CONSOLE_COLORS[level]}${level.toUpperCase()} [${namespace}]\x1b[0m`,
         ...args.map((e) => (e instanceof Error ? ["\n", e] : [e])).flat(),
       );
     };

--- a/src/server/utils/translation.ts
+++ b/src/server/utils/translation.ts
@@ -40,11 +40,10 @@ export const getClosestLanguage = (
 export const dynamicImportTranslationFiles = async (
   path: string,
 ): Promise<TranslationRecord> => {
-  const files = await readdir(join(path, "locales")).catch((e) => {
+  const files = await readdir(join(path, "locales")).catch(() => {
     logger.debug(
       "translation",
-      `Error reading translation directory at path "${path}":`,
-      e,
+      `No "locales" directory found at path "${path}". Skipping translation.`,
     );
     return [];
   });
@@ -64,7 +63,7 @@ export const dynamicImportTranslationFiles = async (
       if (typeof translation === "object" && translation !== null) {
         translations[lang] = translation;
       } else {
-        logger.debug(
+        logger.warn(
           "translation",
           `Translation file for language "${lang}" at path "${path}" does not export an object.`,
         );


### PR DESCRIPTION
# Fix/translation error handler

Fixes stray space in logger and the logger for translations.

## Example

Old logs looked like
```
DEBUG [translation]  Error reading translation directory at path "/app/data/engines/startpage": 
 38 |  * @returns A promise that resolves to the translation record object, or an empty object if an error occurs.
 39 |  */
 40 | export const dynamicImportTranslationFiles = async (
 41 |   path: string,
 42 | ): Promise<TranslationRecord> => {
 43 |   const files = await readdir(join(path, "locales")).catch((e) => {
                                                           ^
 ENOENT: no such file or directory, scandir '/app/data/engines/startpage/locales'
     path: "/app/data/engines/startpage/locales",
  syscall: "scandir",
    errno: -2,
     code: "ENOENT"
 
       at async <anonymous> (/app/src/server/utils/translation.ts:43:54)
       at async <anonymous> (/app/src/server/utils/translation.ts:154:30)
       at async <anonymous> (/app/src/server/extensions/engines/registry.ts:203:30)
       at async loadFromDir (/app/src/server/extensions/registry-factory.ts:192:22)
       at async init (/app/src/server/extensions/registry-factory.ts:209:13)
       at async initEngines (/app/src/server/extensions/engines/registry.ts:545:24)
```

New logs looks like
```
DEBUG [translation] No "locales" directory found at path "/app/data/engines/startpage". Skipping translation.
```

## Clanker

This pull request makes improvements to error handling and logging in the server utilities, specifically in the `logger` and translation-related functions. The main changes focus on making log messages clearer and ensuring that potential issues are logged with appropriate severity.

**Logging improvements:**

* Updated the `logger` utility in `logger.ts` to ensure that color reset codes are properly appended at the end of log messages for better readability in the console.

**Translation utilities:**

* In `translation.ts`, improved error handling when the `locales` directory is missing by simplifying the log message and removing the error object from the output, making logs less noisy.
* Changed the log level from `debug` to `warn` when a translation file does not export an object, making it easier to spot potential translation issues.