### PR TITLE
0.13.1

### DIFF
--- a/docs/aliases.html
+++ b/docs/aliases.html
@@ -34,6 +34,7 @@
         <li><a href="env.html">Environment</a></li>
         <li><a href="styling.html">Styling</a></li>
         <li><a href="translations.html">Translations</a></li>
+        <li><a href="api.html">API</a></li>
       </ul>
     </nav>
 

--- a/docs/api.html
+++ b/docs/api.html
@@ -1,0 +1,215 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>API reference — Degoog docs</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="wrap">
+      <header>
+        <h1><a href="index.html">Degoog</a> — API reference</h1>
+        <p>User-facing HTTP endpoints and a real life usage example.</p>
+      </header>
+
+      <nav class="doc-nav">
+        <div class="doc-search-wrap">
+          <label for="doc-search-input" class="doc-search-label">Search</label>
+          <input
+            type="search"
+            id="doc-search-input"
+            class="doc-search"
+            placeholder="Search docs..."
+            autocomplete="off"
+          />
+          <button
+            type="button"
+            class="doc-search-clear"
+            aria-label="Clear search"
+            style="display: none"
+          >
+            Clear
+          </button>
+          <span class="doc-search-count"></span>
+        </div>
+        <h2>Docs</h2>
+        <ul>
+          <li><a href="index.html">Overview</a></li>
+          <li><a href="plugins.html">Plugins</a></li>
+          <li><a href="themes.html">Themes</a></li>
+          <li><a href="engines.html">Search engines</a></li>
+          <li><a href="transports.html">Transports</a></li>
+          <li><a href="store.html">Store</a></li>
+          <li><a href="aliases.html">Aliases</a></li>
+          <li><a href="env.html">Environment</a></li>
+          <li><a href="styling.html">Styling</a></li>
+          <li><a href="translations.html">Translations</a></li>
+          <li><a href="api.html">API</a></li>
+        </ul>
+      </nav>
+
+      <main>
+        <h2>Overview</h2>
+        <p>
+          Most of Degoog's HTTP surface is internal plumbing for the web UI. The
+          endpoints below are the ones that will most likely be used for
+          external callers.
+        </p>
+        <p>
+          Endpoints live at the same host/port as the UI (<code
+            >http://localhost:4444</code
+          >
+          by default, or <code>DEGOOG_PORT</code>). Responses are JSON. Rate
+          limits is configured in Settings → Server and apply to every caller.
+        </p>
+
+        <h2><code>GET /api/search</code></h2>
+        <p>Run a metasearch and return merged, scored results.</p>
+        <table>
+          <thead>
+            <tr>
+              <th>Param</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>q</code></td>
+              <td>Required. Search query.</td>
+            </tr>
+            <tr>
+              <td><code>type</code></td>
+              <td>
+                <code>web</code> (default) | <code>images</code> |
+                <code>videos</code> | <code>news</code>.
+              </td>
+            </tr>
+            <tr>
+              <td><code>page</code></td>
+              <td>1-based page number. Clamped to <code>1..10</code>.</td>
+            </tr>
+            <tr>
+              <td><code>time</code></td>
+              <td>
+                <code>any</code> | <code>hour</code> | <code>day</code> |
+                <code>week</code> | <code>month</code> | <code>year</code> |
+                <code>custom</code>. For <code>custom</code>, pass
+                <code>dateFrom</code> / <code>dateTo</code>
+                (<code>YYYY-MM-DD</code>).
+              </td>
+            </tr>
+            <tr>
+              <td><code>lang</code></td>
+              <td>
+                ISO 639-1 code. Overrides
+                <code>DEGOOG_DEFAULT_SEARCH_LANGUAGE</code> for this request.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <pre><code>curl "http://localhost:4444/api/search?q=rust+lifetimes"</code></pre>
+        <p>Response:</p>
+        <pre><code>{
+  "results": [
+    {
+      "title": "...",
+      "url": "https://...",
+      "snippet": "...",
+      "source": "google",
+      "score": 92,
+      "sources": ["google", "duckduckgo"]
+    }
+  ],
+  "query": "rust lifetimes",
+  "totalTime": 812,
+  "type": "web",
+  "engineTimings": [{ "name": "Google", "time": 540, "resultCount": 10 }],
+  "relatedSearches": ["rust lifetime elision", "..."]
+}</code></pre>
+
+        <h2><code>POST /api/search</code></h2>
+        <p>
+          Same as the GET form, with a JSON body. Use this when you need a long
+          engine list.
+        </p>
+        <pre><code>curl -X POST http://localhost:4444/api/search \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "rust lifetimes",
+    "type": "web",
+    "page": 1,
+    "lang": "en",
+    "engines": ["google", "duckduckgo"]
+  }'</code></pre>
+
+        <h2><code>GET /api/search/stream</code></h2>
+        <p>
+          Server-Sent Events variant. Same query parameters as
+          <code>GET /api/search</code>. Emits:
+        </p>
+        <ul>
+          <li>
+            <code>engine-result</code> — fired as each engine returns. The
+            <code>results</code> field is the running merged list, so a lazy
+            consumer can just keep the last one.
+          </li>
+          <li>
+            <code>done</code> — final event with <code>totalTime</code>,
+            <code>engineTimings</code>, <code>relatedSearches</code>.
+          </li>
+        </ul>
+        <pre><code>curl -N "http://localhost:4444/api/search/stream?q=hello"</code></pre>
+
+        <h2><code>GET /api/suggest?q=...</code></h2>
+        <p>
+          Autocomplete suggestions merged from Google and DuckDuckGo. Returns
+          <code>string[]</code>.
+        </p>
+
+        <h2><code>GET /api/lucky?q=...</code></h2>
+        <p>
+          Runs a web search and <code>302</code>-redirects to the first result's
+          URL.
+        </p>
+
+        <h2><code>GET /opensearch.xml</code></h2>
+        <p>
+          OpenSearch descriptor — lets browsers install Degoog as a search
+          engine.
+        </p>
+
+        <h2>
+          Tip: wiring Degoog into
+          <a href="https://github.com/open-webui/open-webui">Open WebUI</a>
+        </h2>
+        <p>
+          Degoog is SearXNG-compatible for Open WebUI's built-in web search — no
+          custom tool needed.
+        </p>
+        <ol>
+          <li>Open WebUI → <strong>Admin Panel</strong>.</li>
+          <li>Go to <strong>Settings</strong>.</li>
+          <li>Select <strong>Web Search</strong> and enable it.</li>
+          <li>
+            Set <strong>Web Search Engine</strong> to <code>searxng</code>.
+          </li>
+          <li>
+            Set <strong>SearxNG Query URL</strong> to your Degoog instance URL +
+            <code>/api/search</code>, e.g.
+            <code>http://127.0.0.1:4444/api/search</code>.
+          </li>
+        </ol>
+        <p>
+          Replace <code>http://127.0.0.1:4444</code> with your actual Degoog
+          address.
+        </p>
+      </main>
+
+      <footer>
+        <a href="index.html">← Overview</a>
+      </footer>
+    </div>
+    <script src="docs.js"></script>
+  </body>
+</html>

--- a/docs/contributing.html
+++ b/docs/contributing.html
@@ -47,6 +47,7 @@
           <li><a href="env.html">Environment</a></li>
           <li><a href="styling.html">Styling</a></li>
           <li><a href="translations.html">Translations</a></li>
+          <li><a href="api.html">API</a></li>
         </ul>
       </nav>
 

--- a/docs/docs.js
+++ b/docs/docs.js
@@ -11,6 +11,7 @@
     "env.html",
     "styling.html",
     "contributing.html",
+    "api.html",
   ];
 
   var searchDebounceTimer = null;

--- a/docs/engines.html
+++ b/docs/engines.html
@@ -45,6 +45,7 @@
           <li><a href="env.html">Environment</a></li>
           <li><a href="styling.html">Styling</a></li>
           <li><a href="translations.html">Translations</a></li>
+          <li><a href="api.html">API</a></li>
         </ul>
       </nav>
 

--- a/docs/env.html
+++ b/docs/env.html
@@ -45,6 +45,7 @@
           <li><a href="env.html">Environment</a></li>
           <li><a href="styling.html">Styling</a></li>
           <li><a href="translations.html">Translations</a></li>
+          <li><a href="api.html">API</a></li>
         </ul>
       </nav>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -48,6 +48,7 @@
           <li><a href="env.html">Environment</a></li>
           <li><a href="styling.html">Styling</a></li>
           <li><a href="translations.html">Translations</a></li>
+          <li><a href="api.html">API</a></li>
         </ul>
       </nav>
 

--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -48,6 +48,7 @@
           <li><a href="env.html">Environment</a></li>
           <li><a href="styling.html">Styling</a></li>
           <li><a href="translations.html">Translations</a></li>
+          <li><a href="api.html">API</a></li>
         </ul>
       </nav>
 

--- a/docs/store.html
+++ b/docs/store.html
@@ -48,6 +48,7 @@
           <li><a href="env.html">Environment</a></li>
           <li><a href="styling.html">Styling</a></li>
           <li><a href="translations.html">Translations</a></li>
+          <li><a href="api.html">API</a></li>
         </ul>
       </nav>
 

--- a/docs/styling.html
+++ b/docs/styling.html
@@ -45,6 +45,7 @@
           <li><a href="env.html">Environment</a></li>
           <li><a href="styling.html">Styling</a></li>
           <li><a href="translations.html">Translations</a></li>
+          <li><a href="api.html">API</a></li>
         </ul>
       </nav>
 

--- a/docs/themes.html
+++ b/docs/themes.html
@@ -45,6 +45,7 @@
           <li><a href="env.html">Environment</a></li>
           <li><a href="styling.html">Styling</a></li>
           <li><a href="translations.html">Translations</a></li>
+          <li><a href="api.html">API</a></li>
         </ul>
       </nav>
 

--- a/docs/translations.html
+++ b/docs/translations.html
@@ -47,6 +47,7 @@
           <li><a href="env.html">Environment</a></li>
           <li><a href="styling.html">Styling</a></li>
           <li><a href="translations.html">Translations</a></li>
+          <li><a href="api.html">API</a></li>
         </ul>
       </nav>
 

--- a/docs/transports.html
+++ b/docs/transports.html
@@ -45,6 +45,7 @@
           <li><a href="env.html">Environment</a></li>
           <li><a href="styling.html">Styling</a></li>
           <li><a href="translations.html">Translations</a></li>
+          <li><a href="api.html">API</a></li>
         </ul>
       </nav>
 

--- a/src/client/settings/general-tab.ts
+++ b/src/client/settings/general-tab.ts
@@ -38,15 +38,16 @@ export async function initAppearanceSettings(): Promise<void> {
       const value = select?.value ?? "system";
       try {
         const token = sessionStorage.getItem("degoog-settings-token");
-        if (!token) throw new Error("missing token");
-        await fetch("/api/settings/general", {
+        const headers: Record<string, string> = {
+          "Content-Type": "application/json",
+        };
+        if (token) headers["x-settings-token"] = token;
+        const res = await fetch("/api/settings/general", {
           method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "x-settings-token": token,
-          },
+          headers,
           body: JSON.stringify({ defaultTheme: value }),
         });
+        if (!res.ok) throw new Error("save failed");
         if (btn) {
           const prev = btn.textContent;
           btn.textContent = t("settings-page.server.saved");

--- a/src/client/utils/search-actions.ts
+++ b/src/client/utils/search-actions.ts
@@ -140,18 +140,19 @@ export async function performSearch(
     );
   }
 
+  const resolvedPage = page && page > 0 ? page : 1;
   state.currentQuery = query;
   state.currentType = resolvedType;
-  state.currentPage = 1;
+  state.currentPage = resolvedPage;
   state.lastPage = MAX_PAGE;
-  state.imagePage = 1;
+  state.imagePage = resolvedPage;
   state.imageLastPage = MAX_PAGE;
-  state.videoPage = 1;
+  state.videoPage = resolvedPage;
   state.videoLastPage = MAX_PAGE;
   destroyMediaObserver();
 
   const engines = await getEngines();
-  const url = buildSearchUrl(query, engines, resolvedType, 1);
+  const url = buildSearchUrl(query, engines, resolvedType, resolvedPage);
 
   setActiveTab(resolvedType);
   closeMediaPreview();
@@ -193,7 +194,12 @@ export async function performSearch(
   document.title = `${query} - degoog`;
 
   if (state.postMethodEnabled) {
-    const historyState = { degoog: true, query, type: resolvedType, page: 1 };
+    const historyState = {
+      degoog: true,
+      query,
+      type: resolvedType,
+      page: resolvedPage,
+    };
     if (isInit) {
       history.replaceState(historyState, "", "/search");
     } else {
@@ -202,6 +208,7 @@ export async function performSearch(
   } else {
     const urlParams = new URLSearchParams({ q: query });
     if (resolvedType !== "web") urlParams.set("type", resolvedType);
+    if (resolvedPage > 1) urlParams.set("page", String(resolvedPage));
     history.replaceState(null, "", `/search?${urlParams.toString()}`);
   }
 
@@ -219,7 +226,7 @@ export async function performSearch(
       ? await fetch("/api/search", {
           method: "POST",
           body: JSON.stringify(
-            buildSearchBody(query, engines, resolvedType, 1),
+            buildSearchBody(query, engines, resolvedType, resolvedPage),
           ),
           headers: { "Content-Type": "application/json" },
         })

--- a/src/server/extensions/engines/registry.ts
+++ b/src/server/extensions/engines/registry.ts
@@ -99,6 +99,7 @@ const BUILTIN_DEFINITIONS: EngineDefinition[] = [
     searchType: "images",
     EngineClass: GoogleImagesEngine,
     outgoingHosts: ["www.google.com", "google.com"],
+    defaultTransport: "curl",
   },
   {
     id: "bing-images",
@@ -233,7 +234,9 @@ export function getOutgoingAllowlist(): string[] {
   const fromBuiltins = BUILTIN_DEFINITIONS.flatMap(
     (d) => d.outgoingHosts ?? [],
   );
-  const fromPlugins = engineRegistry.items().flatMap((e) => e.outgoingHosts ?? []);
+  const fromPlugins = engineRegistry
+    .items()
+    .flatMap((e) => e.outgoingHosts ?? []);
   const all = [...fromBuiltins, ...fromPlugins];
   return [...new Set(all)];
 }
@@ -256,7 +259,8 @@ function engineSearchTypeFromSearchType(
 export function getEnginesForCustomType(
   engineType: string,
 ): { id: string; instance: SearchEngine }[] {
-  return engineRegistry.items()
+  return engineRegistry
+    .items()
     .filter((e) => e.searchType === engineType)
     .map((e) => ({ id: e.id, instance: e.instance }));
 }
@@ -559,7 +563,8 @@ export function getAllEngineTranslators(): {
   namespace: string;
   translator: Translate;
 }[] {
-  return engineRegistry.items()
+  return engineRegistry
+    .items()
     .filter((e) => !!e.instance.t)
     .map((e) => ({ namespace: `engines/${e.id}`, translator: e.instance.t! }));
 }

--- a/src/server/extensions/themes/registry.ts
+++ b/src/server/extensions/themes/registry.ts
@@ -1,6 +1,5 @@
 import { mkdir, readdir, readFile } from "fs/promises";
 import { join } from "path";
-import * as sass from "sass";
 import {
   type ExtensionMeta,
   ExtensionStoreType,
@@ -63,10 +62,6 @@ async function compileThemeCss(
 
   const fullPath = join(theme.dir, cssFile);
   try {
-    if (cssFile.endsWith(".scss")) {
-      const result = sass.compile(fullPath);
-      return result.css;
-    }
     return await readFile(fullPath, "utf-8");
   } catch (err) {
     logger.debug("themes", `Failed to compile CSS for theme ${theme.id}`, err);

--- a/src/server/routes/plugin-assets.ts
+++ b/src/server/routes/plugin-assets.ts
@@ -62,7 +62,7 @@ router.get("/plugins/:folder/*", async (c) => {
     const ns = getPluginNamespace(folder);
     if (ns) {
       const code = await file.text();
-      const scoped = `(function(t){${code}})(window.scopedT(${JSON.stringify(ns)}));`;
+      const scoped = `(function(t){${code}\n})(window.scopedT(${JSON.stringify(ns)}));`;
       return c.body(scoped);
     }
   }
@@ -93,7 +93,7 @@ router.get("/themes/:folder/*", async (c) => {
   if (ext === ".js" || ext === ".mjs") {
     const ns = `themes/${folder}`;
     const code = await file.text();
-    const scoped = `(function(t){${code}})(window.scopedT(${JSON.stringify(ns)}));`;
+    const scoped = `(function(t){${code}\n})(window.scopedT(${JSON.stringify(ns)}));`;
     return c.body(scoped);
   }
   return c.body(await file.arrayBuffer());

--- a/src/server/routes/search-stream.ts
+++ b/src/server/routes/search-stream.ts
@@ -11,6 +11,7 @@ import {
 } from "../search";
 import {
   EngineTiming,
+  ScoredResult,
   SearchResponse,
   SearchResult,
   SearchType,
@@ -18,6 +19,10 @@ import {
 } from "../types";
 import * as cache from "../utils/cache";
 import { asString, getSettings } from "../utils/plugin-settings";
+import {
+  applyDomainReplacements,
+  filterBlockedDomains,
+} from "../utils/domain-filter";
 import {
   _applyRateLimit,
   cacheKey,
@@ -158,6 +163,13 @@ router.get("/api/search/stream", async (c) => {
         }
       }
 
+      const _applyDomainRules = async (
+        results: ScoredResult[],
+      ): Promise<ScoredResult[]> => {
+        const afterBlock = await filterBlockedDomains(results);
+        return await applyDomainReplacements(afterBlock);
+      };
+
       const enginePromises = rawActiveEngines.map(
         async ({ instance, score, id }) => {
           const engineName = instance.name;
@@ -187,7 +199,7 @@ router.get("/api/search/stream", async (c) => {
               _send("engine-result", {
                 engine: engineName,
                 timing,
-                results: scoreResults(allRawResults),
+                results: await _applyDomainRules(scoreResults(allRawResults)),
                 retry: isRetry,
                 attempt,
               });
@@ -209,7 +221,7 @@ router.get("/api/search/stream", async (c) => {
           _send("engine-result", {
             engine: engineName,
             timing: lastTiming,
-            results: scoreResults(allRawResults),
+            results: await _applyDomainRules(scoreResults(allRawResults)),
             retry: false,
             attempt: 0,
           });
@@ -218,7 +230,9 @@ router.get("/api/search/stream", async (c) => {
 
       void Promise.all(enginePromises).then(async () => {
         const totalTime = Math.round(performance.now() - start);
-        const finalResults = scoreResults(allRawResults);
+        const finalResults = await _applyDomainRules(
+          scoreResults(allRawResults),
+        );
         let relatedSearches: string[] = [];
         if (searchType === "web" && page === 1) {
           relatedSearches = await fetchRelatedSearches(query).catch(

--- a/src/server/search.ts
+++ b/src/server/search.ts
@@ -167,25 +167,34 @@ export const createSearchEngineContext = (
   lang?: string,
   dateFrom?: string,
   dateTo?: string,
-): EngineContext => ({
-  fetch: async (url, init) => {
-    let raw: string | undefined;
-    if (engineSettingsId !== undefined) {
-      raw =
-        asString((await getSettings(engineSettingsId)).outgoingTransport) ||
-        undefined;
-    }
-    if (!raw && engineSettingsId !== undefined) {
-      raw = getEngineDefaultTransport(engineSettingsId) ?? undefined;
-    }
-    const transport = parseOutgoingTransport(raw);
-    return outgoingFetch(url, init ?? {}, transport);
-  },
-  lang: lang || undefined,
-  dateFrom: dateFrom || undefined,
-  dateTo: dateTo || undefined,
-  buildAcceptLanguage: () => _buildAcceptLanguage(lang),
-});
+): EngineContext => {
+  const resolvedLang =
+    lang ||
+    (process.env.DEGOOG_DEFAULT_SEARCH_LANGUAGE || "")
+      .trim()
+      .split(/[-_]/)[0]
+      .toLowerCase() ||
+    undefined;
+  return {
+    fetch: async (url, init) => {
+      let raw: string | undefined;
+      if (engineSettingsId !== undefined) {
+        raw =
+          asString((await getSettings(engineSettingsId)).outgoingTransport) ||
+          undefined;
+      }
+      if (!raw && engineSettingsId !== undefined) {
+        raw = getEngineDefaultTransport(engineSettingsId) ?? undefined;
+      }
+      const transport = parseOutgoingTransport(raw);
+      return outgoingFetch(url, init ?? {}, transport);
+    },
+    lang: resolvedLang,
+    dateFrom: dateFrom || undefined,
+    dateTo: dateTo || undefined,
+    buildAcceptLanguage: () => _buildAcceptLanguage(resolvedLang),
+  };
+};
 
 export const searchSingleEngine = async (
   engineName: string,

--- a/src/server/utils/logger.ts
+++ b/src/server/utils/logger.ts
@@ -22,8 +22,7 @@ export const logger = LEVELS.reduce(
     acc[level] = (namespace: string, ...args: unknown[]) => {
       if (LEVELS.indexOf(LOG_LEVEL) < LEVELS.indexOf(level)) return;
       CONSOLE_LEVELS[level](
-        `${CONSOLE_COLORS[level]}${level.toUpperCase()} [${namespace}]`,
-        "\x1b[0m",
+        `${CONSOLE_COLORS[level]}${level.toUpperCase()} [${namespace}]\x1b[0m`,
         ...args.map((e) => (e instanceof Error ? ["\n", e] : [e])).flat(),
       );
     };

--- a/src/server/utils/translation.ts
+++ b/src/server/utils/translation.ts
@@ -279,6 +279,6 @@ export const injectScope = (html: string, namespace: string): string => {
   return html.replace(
     /(<script\b[^>]*>)([\s\S]*?)(<\/script>)/gi,
     (_, open, body, close) =>
-      `${open}(function(t){${body}})(typeof window.scopedT==="function"?window.scopedT(${ns}):function(k){return k});${close}`,
+      `${open}(function(t){${body}\n})(typeof window.scopedT==="function"?window.scopedT(${ns}):function(k){return k});${close}`,
   );
 };

--- a/src/server/utils/translation.ts
+++ b/src/server/utils/translation.ts
@@ -40,11 +40,10 @@ export const getClosestLanguage = (
 export const dynamicImportTranslationFiles = async (
   path: string,
 ): Promise<TranslationRecord> => {
-  const files = await readdir(join(path, "locales")).catch((e) => {
+  const files = await readdir(join(path, "locales")).catch(() => {
     logger.debug(
       "translation",
-      `Error reading translation directory at path "${path}":`,
-      e,
+      `No "locales" directory found at path "${path}". Skipping translation.`,
     );
     return [];
   });
@@ -64,7 +63,7 @@ export const dynamicImportTranslationFiles = async (
       if (typeof translation === "object" && translation !== null) {
         translations[lang] = translation;
       } else {
-        logger.debug(
+        logger.warn(
           "translation",
           `Translation file for language "${lang}" at path "${path}" does not export an object.`,
         );

--- a/tests/routes/search.test.ts
+++ b/tests/routes/search.test.ts
@@ -3,15 +3,10 @@ import { describe, test, expect, beforeAll } from "bun:test";
 let searchRouter: {
   request: (req: Request | string) => Response | Promise<Response>;
 };
-let slotsRouter: {
-  request: (req: Request | string) => Response | Promise<Response>;
-};
 
 beforeAll(async () => {
   const mod = await import("../../src/server/routes/search");
   searchRouter = mod.default;
-  const slotsMod = await import("../../src/server/routes/slots");
-  slotsRouter = slotsMod.default;
 });
 
 describe("routes/search", () => {


### PR DESCRIPTION
# Changelog

**bugfixes**

- Fix translation error handler and move it to a warning type log rather than debugger #77
- Remove sass build from theme registry, this means theme developers won't be able to use raw .scss files anymore, if they want to use sass they'll need to pre-compile before pushing the theme to the repo. This reduces ram usage to 2/3, so it's a no brainer.
- Fix "Save as instance default" when no password set #80
- search results paging was always showing the same results (whops) #80
- domain blocking/replacement was not working with streaming enabled #80
- script.js used to break if last line is a comment #80
- setting DEGOOG_DEFAULT_SEARCH_LANGUAGE has no effect #88 


**admin**

- Add github issue templates so issues will be more structured from now on
- Add initial documentation for API