### PR TITLE
Bugfix/remove sass from themes

### DIFF
--- a/src/server/extensions/themes/registry.ts
+++ b/src/server/extensions/themes/registry.ts
@@ -1,6 +1,5 @@
 import { mkdir, readdir, readFile } from "fs/promises";
 import { join } from "path";
-import * as sass from "sass";
 import {
   type ExtensionMeta,
   ExtensionStoreType,
@@ -63,10 +62,6 @@ async function compileThemeCss(
 
   const fullPath = join(theme.dir, cssFile);
   try {
-    if (cssFile.endsWith(".scss")) {
-      const result = sass.compile(fullPath);
-      return result.css;
-    }
     return await readFile(fullPath, "utf-8");
   } catch (err) {
     logger.debug("themes", `Failed to compile CSS for theme ${theme.id}`, err);


### PR DESCRIPTION
Remove SASS dependency from theme registry.
This unfortunately means third party themes won't be able to use sass, HOWEVER it reduces memory usage by 2/3, so it's an absolutely worth trade off.

left: idle before change
right: idle after change

<img width="369" height="120" alt="image" src="https://github.com/user-attachments/assets/9a6f44e4-11c0-4e40-a667-110adef5428f" />

<img width="370" height="124" alt="image" src="https://github.com/user-attachments/assets/3ca851d5-72a6-48bd-a2d7-7caa6f5d9a92" />

