### PR TITLE
Fix/add proxy auth when using fetch

### DIFF
--- a/src/public/settings.html
+++ b/src/public/settings.html
@@ -633,7 +633,7 @@
                       id="settings-proxy-urls"
                       class="settings-proxy-urls"
                       rows="4"
-                      placeholder="http://proxy1:8080&#10;socks5://proxy2:1080"
+                      placeholder="http://proxy1:8080&#10;http://user:pass@proxy2:8080&#10;socks5://proxy3:1080"
                     ></textarea>
                     <button
                       class="btn btn--secondary proxy-test-btn"

--- a/src/server/utils/http-proxy-fetch.ts
+++ b/src/server/utils/http-proxy-fetch.ts
@@ -6,9 +6,24 @@ import type { TransportFetchOptions as OutgoingFetchOptions } from "../types";
 const MAX_REDIRECTS = 5;
 const CONNECT_TIMEOUT_MS = 8_000;
 
-function parseProxyUrl(proxyUrl: string): { host: string; port: number } {
+function parseProxyUrl(proxyUrl: string): {
+  host: string;
+  port: number;
+  auth: string | undefined;
+} {
   const url = new URL(proxyUrl);
-  return { host: url.hostname, port: Number(url.port) || 8080 };
+  const username = decodeURIComponent(url.username);
+  const password = decodeURIComponent(url.password);
+  const auth =
+    username || password
+      ? `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`
+      : undefined;
+
+  return {
+    host: url.hostname,
+    port: Number(url.port) || 80,
+    auth,
+  };
 }
 
 const _openConnectTunnel = (
@@ -16,6 +31,7 @@ const _openConnectTunnel = (
   proxyPort: number,
   targetHost: string,
   targetPort: number,
+  proxyAuth: string | undefined,
   timeoutMs: number = CONNECT_TIMEOUT_MS,
 ): Promise<net.Socket> =>
   new Promise((resolve, reject) => {
@@ -26,8 +42,9 @@ const _openConnectTunnel = (
     }, timeoutMs);
 
     sock.once("connect", () => {
+      const authHeader = proxyAuth ? `Proxy-Authorization: ${proxyAuth}` : "";
       sock.write(
-        `CONNECT ${targetHost}:${targetPort} HTTP/1.1\r\nHost: ${targetHost}:${targetPort}\r\n\r\n`,
+        `CONNECT ${targetHost}:${targetPort} HTTP/1.1\r\nHost: ${targetHost}:${targetPort}\r\n${authHeader}\r\n\r\n`,
       );
     });
 
@@ -59,6 +76,7 @@ const _openConnectTunnel = (
 async function _openProxySocket(
   proxyHost: string,
   proxyPort: number,
+  proxyAuth: string | undefined,
   targetHost: string,
   targetPort: number,
   useTls: boolean,
@@ -69,6 +87,7 @@ async function _openProxySocket(
     proxyPort,
     targetHost,
     targetPort,
+    proxyAuth,
     timeoutMs,
   );
   if (!useTls) return sock;
@@ -174,7 +193,8 @@ export async function fetchViaHttpProxy(
   options: OutgoingFetchOptions = {},
   timeoutMs?: number,
 ): Promise<Response> {
-  const { host: proxyHost, port: proxyPort } = parseProxyUrl(proxyUrl);
+  const { host: proxyHost, port: proxyPort, auth: proxyAuth } =
+    parseProxyUrl(proxyUrl);
   const followRedirects = (options.redirect ?? "follow") !== "manual";
   const method = options.method ?? "GET";
 
@@ -189,6 +209,7 @@ export async function fetchViaHttpProxy(
     const sock = await _openProxySocket(
       proxyHost,
       proxyPort,
+      proxyAuth,
       parsed.hostname,
       port,
       useTls,

--- a/src/server/utils/http-proxy-fetch.ts
+++ b/src/server/utils/http-proxy-fetch.ts
@@ -21,7 +21,7 @@ function parseProxyUrl(proxyUrl: string): {
 
   return {
     host: url.hostname,
-    port: Number(url.port) || 80,
+    port: Number(url.port) || url.protocol == "http:" ? 80 : 443,
     auth,
   };
 }
@@ -42,9 +42,9 @@ const _openConnectTunnel = (
     }, timeoutMs);
 
     sock.once("connect", () => {
-      const authHeader = proxyAuth ? `Proxy-Authorization: ${proxyAuth}` : "";
+      const authHeader = proxyAuth ? `Proxy-Authorization: ${proxyAuth}\r\n` : "";
       sock.write(
-        `CONNECT ${targetHost}:${targetPort} HTTP/1.1\r\nHost: ${targetHost}:${targetPort}\r\n${authHeader}\r\n\r\n`,
+        `CONNECT ${targetHost}:${targetPort} HTTP/1.1\r\nHost: ${targetHost}:${targetPort}\r\n${authHeader}\r\n`,
       );
     });
 

--- a/src/server/utils/http-proxy-fetch.ts
+++ b/src/server/utils/http-proxy-fetch.ts
@@ -21,7 +21,7 @@ function parseProxyUrl(proxyUrl: string): {
 
   return {
     host: url.hostname,
-    port: Number(url.port) || url.protocol == "http:" ? 80 : 443,
+    port: Number(url.port) || (url.protocol === "http:" ? 80 : 443),
     auth,
   };
 }


### PR DESCRIPTION
I found that the `fetch` transport mode didn't work when using a proxy of the format: `http://user:pass@proxy:port`.
This meant that pressing "Test proxy connection" in the settings would fail, but if the `curl` transport mode was used, one would still be able to search as per usual. However, if using the `fetch` transport mode, searching would not work.

I have made an attempt at fixing this, so that the `fetch` transport mode now supports Basic authentication.
However, these changes are breaking, since the default port is now either 80 or 443 based on the protocol of the proxy.
This is because the `new URL(proxyUrl);` ignores the default port (i.e. 80 or 443), resulting in `url.port` being an empty string, which would result in port 8080 being used previously.

Please let me know if I need to change anything! :)
